### PR TITLE
fix: resolve zizmor findings and update tooling configs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ jobs:
         language: ["actions", "javascript"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/codeql-analysis@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/pr-lint@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+        uses: ivuorinen/actions/pr-lint@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04
 
   publish:
     name: Publish

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,4 +27,4 @@ jobs:
       issues: write # required to close and comment on stale issues
       pull-requests: write # required to close and comment on stale PRs
     steps:
-      - uses: ivuorinen/actions/stale@8395dad6b7d5d7d2e1d016cac1eede33ab404a3c # v2026.06.18
+      - uses: ivuorinen/actions/stale@94a4f68a6b95ecc1677fbcac1683119fd869adf7 # v2026.07.04

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -3,6 +3,13 @@
 # See all available variables at
 # https://megalinter.io/configuration/ and in linters documentation
 
+# Ensure zizmor runs authenticated: MegaLinter unsets GITHUB_TOKEN for linters
+# unless listed here, which left zizmor unauthenticated and failing
+# impostor-commit with HTTP 401.
+# https://megalinter.io/latest/descriptors/action_zizmor/
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN
+
 APPLY_FIXES: all
 SHOW_ELAPSED_TIME: false # Show elapsed time at the end of MegaLinter run
 PARALLEL: true


### PR DESCRIPTION
## Summary

- Allow `GITHUB_TOKEN` for zizmor in MegaLinter (`ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES`)
- Bump pinned action versions

Workflows were already clean under `zizmor -p`.

## Verification

- `zizmor -p .github/workflows`: no findings
- `prek run --from-ref main --to-ref HEAD`: all hooks pass